### PR TITLE
Use matplotlib colormaps API for bar plot gradients

### DIFF
--- a/bymacclbot.py
+++ b/bymacclbot.py
@@ -13,7 +13,7 @@ import requests
 import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
-import matplotlib.cm as cm
+from matplotlib import colormaps
 from matplotlib.colors import Normalize
 
 from telegram import Update
@@ -166,10 +166,10 @@ def plot_top_bottom(real_returns: pd.Series, top_n: int, bottom_n: int,
     worst = rr.nsmallest(bottom_n)
 
     norm_pos = Normalize(vmin=float(best.min()), vmax=float(best.max()))
-    colors_pos = cm.get_cmap(cmap_pos)(norm_pos(best.values))
+    colors_pos = colormaps.get_cmap(cmap_pos)(norm_pos(best.values))
 
     norm_neg = Normalize(vmin=float(np.abs(worst).min()), vmax=float(np.abs(worst).max()))
-    colors_neg = cm.get_cmap(cmap_neg)(norm_neg(np.abs(worst.values)))
+    colors_neg = colormaps.get_cmap(cmap_neg)(norm_neg(np.abs(worst.values)))
 
     fig = plt.figure(figsize=(11.5, 8.5), dpi=150)
     gs = fig.add_gridspec(2, 1, height_ratios=[1, 1], hspace=0.32)


### PR DESCRIPTION
## Summary
- import matplotlib colormaps and use new API for color selection in `plot_top_bottom`

## Testing
- `python -m py_compile bymacclbot.py`
- `python - <<'PY'
import numpy as np, pandas as pd
from bymacclbot import plot_top_bottom
ser = pd.Series([10,20,-5,-10,15,0], index=[f'T{i}' for i in range(6)])
img = plot_top_bottom(ser, 3, 3, '2020-01-01', '2020-12-31', False)
print('img bytes:', len(img.getvalue()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c15bad4b7483228173123a6e080410