### PR TITLE
Clarificar uso multi-ticker de /cclplot

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Bot público: **[@BYMAcclBot](https://t.me/bymacclBot)**
   Grafica **Top N / Bottom M** de rendimientos en **USD (vía CCL)** para el rango guardado.  
   Ejemplo: `/cclvars 15 20`.
 
-- **/cclplot TICKER**  
-  Grafica la serie en **USD (vía CCL)** de `TICKER.BA` para el rango guardado.  
-  Respeta el flag de normalización.  
-  Ejemplo: `/cclplot BBAR`.
+- **/cclplot TICKER1 [TICKER2 ...]**
+  Grafica la serie en **USD (vía CCL)** de uno o varios tickers `TICKER.BA` para el rango guardado.
+  Respeta el flag de normalización para todos.
+  Ejemplo: `/cclplot BBAR GGAL`.
 
 - **/normalize**  
   Alterna el flag `normalize` entre **True/False** (persistente por chat) y explica el efecto:  

--- a/bymacclbot.py
+++ b/bymacclbot.py
@@ -276,7 +276,7 @@ def plot_tickers_usd(tickers: list[str], start: str, end: str, normalize_flag: b
 async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     s, e = get_dates(update.effective_chat.id)
     norm = get_normalize(update.effective_chat.id)
-    msg = "Comandos: /ini YYYY-MM-DD | /fin YYYY-MM-DD | /cclvars N M | /cclplot TICKER | /normalize\n"
+    msg = "Comandos: /ini YYYY-MM-DD | /fin YYYY-MM-DD | /cclvars N M | /cclplot TICKER1 [TICKER2 ...] | /normalize\n"
     msg += f"Rango actual: inicio={s or '⟂'} | fin={e or '⟂'} | normalize={norm}"
     await update.message.reply_text(msg)
 


### PR DESCRIPTION
## Summary
- Mostrar en `/start` que `/cclplot` acepta más de un ticker
- Documentar en README el uso de `/cclplot` con varios tickers y la normalización aplicada a todos

## Testing
- `python -m py_compile bymacclbot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1747869c883228503761af8359a30