### PR TITLE
Add configurable logging level and detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ numpy
 
 - **Token**: variable de entorno `TELEGRAM_BOT_TOKEN` (otorgado por BotFather).  
 - **Persistencia**: archivo `state.json` en la raíz (se crea automáticamente).  
-- **Logs**: nivel `INFO` por defecto.
+- **Logs**: nivel `INFO` por defecto (`LOG_LEVEL` para ajustarlo, p.ej., `DEBUG`).
 
 > **Seguridad**: no publiques tu token en repos/commits. Usá variables de entorno, `.env` o secrets del proveedor.
 

--- a/bymacclbot.py
+++ b/bymacclbot.py
@@ -23,7 +23,11 @@ from telegram.ext import Application, CommandHandler, ContextTypes
 TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "REEMPLAZA_CON_TU_TOKEN")
 STATE_FILE = Path("state.json")  # persistencia por chat_id
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, log_level, logging.INFO),
+    format="%(asctime)s %(name)s %(module)s:%(lineno)d %(levelname)s %(message)s",
+)
 log = logging.getLogger("ccl-bot")
 
 # ------------------ UTIL / PERSISTENCIA -------------


### PR DESCRIPTION
## Summary
- Include logger name, module and line info in logging output
- Allow overriding log level via `LOG_LEVEL` environment variable
- Document `LOG_LEVEL` in README

## Testing
- `python -m py_compile bymacclbot.py`

------
https://chatgpt.com/codex/tasks/task_e_68c810d47ef88322b5064b2afe00aa6d