### PR TITLE
Guard command handlers against missing chat/message

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -11,6 +11,7 @@ class CommandHandlersTests(unittest.IsolatedAsyncioTestCase):
         message = SimpleNamespace(reply_text=AsyncMock())
         update = SimpleNamespace(
             effective_chat=SimpleNamespace(id=chat_id),
+            effective_message=message,
             message=message,
         )
         context = SimpleNamespace(args=["2015-01-01"])
@@ -28,6 +29,7 @@ class CommandHandlersTests(unittest.IsolatedAsyncioTestCase):
         message = SimpleNamespace(reply_text=AsyncMock())
         update = SimpleNamespace(
             effective_chat=SimpleNamespace(id=chat_id),
+            effective_message=message,
             message=message,
         )
         context = SimpleNamespace(args=["2020-12-31"])
@@ -39,6 +41,46 @@ class CommandHandlersTests(unittest.IsolatedAsyncioTestCase):
         message.reply_text.assert_awaited_once_with(
             "Fecha final guardada: 2020-12-31"
         )
+
+    async def test_cmd_ini_handles_missing_message_with_fallback(self):
+        chat_id = 999
+        update = SimpleNamespace(
+            effective_chat=SimpleNamespace(id=chat_id),
+            effective_message=None,
+        )
+        bot = SimpleNamespace(send_message=AsyncMock())
+        context = SimpleNamespace(args=["2015-01-01"], bot=bot)
+
+        with patch("bymacclbot.set_date", autospec=True) as mock_set_date:
+            with self.assertLogs(bymacclbot.log, level="WARNING") as cm:
+                await bymacclbot.cmd_ini(update, context)
+                mock_set_date.assert_called_once_with(chat_id, "start", "2015-01-01")
+
+        self.assertTrue(
+            any("cmd_ini invoked without effective_message" in msg for msg in cm.output)
+        )
+        bot.send_message.assert_awaited_once_with(
+            chat_id,
+            "Fecha inicial guardada: 2015-01-01",
+        )
+
+    async def test_cmd_ini_returns_early_when_chat_missing(self):
+        message = SimpleNamespace(reply_text=AsyncMock())
+        update = SimpleNamespace(
+            effective_chat=None,
+            effective_message=message,
+        )
+        context = SimpleNamespace(args=["2015-01-01"])
+
+        with patch("bymacclbot.set_date", autospec=True) as mock_set_date:
+            with self.assertLogs(bymacclbot.log, level="WARNING") as cm:
+                await bymacclbot.cmd_ini(update, context)
+                mock_set_date.assert_not_called()
+
+        self.assertTrue(
+            any("cmd_ini invoked without effective_chat" in msg for msg in cm.output)
+        )
+        message.reply_text.assert_not_called()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- add helper functions to safely reply via message or bot fallback when chat/message objects are missing
- harden command handlers to guard effective_chat/effective_message lookups, log anomalies, and reuse the new reply helpers
- extend command handler tests to cover missing message/chat scenarios and assert graceful behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cca63486408322a8c3f0c9e6e0d014